### PR TITLE
Added scopes, guest authorization flow, updated markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Spotify oAuth Proxy
+
 ## Contents
 
 1. [Overview](#overview)
-2. [Deploy](#deploy)   
+2. [Deploy](#deploy)
 3. [Workflows](#workflows)
-    1. [Authorization Code Flow](#authflow)
-    2. [Client Credentials Flow (Guest Access)](#clientflow)
-    3. [Multiple Authorization Flows](#multipleflows)
+   1. [Authorization Code Flow](#authflow)
+   2. [Client Credentials Flow (Guest Access)](#clientflow)
+   3. [Multiple Authorization Flows](#multipleflows)
 
 ## Overview <a name="overview"></a>
 
@@ -16,13 +17,13 @@ This is a deployable server that allows you to use either the Spotify Authorizat
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-Key | Value
----  | ---
-CLIENT_SECRET | Your client secret
-CLIENT_ID | Your client id
-APP_URL | URL for your front-end app
-SERVER_URL | URL for the deployed herokuapp
-SCOPES | The authorization scopes you want the user to grant; scopes should be separated with a space. A full list of available scopes can be found [here](https://developer.spotify.com/documentation/general/guides/scopes/). If no scopes are specified, authorization will be granted only to access publicly available information.
+| Key               | Value                                                                                                                                                                                                                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CLIENT_SECRET     | Your client secret                                                                                                                                                                                                                                                                                                              |
+| CLIENT_ID         | Your client id                                                                                                                                                                                                                                                                                                                  |
+| APP_URL           | URL for your front-end app                                                                                                                                                                                                                                                                                                      |
+| SERVER_URL        | URL for the deployed herokuapp                                                                                                                                                                                                                                                                                                  |
+| SCOPES (optional) | The authorization scopes you want the user to grant; scopes should be separated with a space. A full list of available scopes can be found [here](https://developer.spotify.com/documentation/general/guides/scopes/). If no scopes are specified, authorization will be granted only to access publicly available information. |
 
 When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and make sure you add the five from above.
 
@@ -30,9 +31,9 @@ When you deploy to Heroku go to your application in the dashboard and click on t
 
 ### Authorization Code Flow <a name="authflow"></a>
 
-Here is the workflow for working with this server in your front-end application. This authorization flow requires the user to grant permission for your app to use their credentials to obtain an access token and refresh token and make calls to the Spotify API on their behalf. More information on this flow can be found [here](https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow). 
+Here is the workflow for working with this server in your front-end application. This authorization flow requires the user to grant permission for your app to use their credentials to obtain an access token and refresh token and make calls to the Spotify API on their behalf. More information on this flow can be found [here](https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow).
 
-Create a link that goes to the deployed servers URL and the `/auth` endpoint, where `https://someapp.herokuapp.com` is the URL for your Heroku server..
+Create a link that goes to the deployed server's URL and the `/auth` endpoint, where `https://someapp.herokuapp.com` is the URL for your Heroku server..
 
 ```html
 <a href="https://someapp.herokuapp.com/auth">Login to Spotify</a>
@@ -56,8 +57,8 @@ However in order to get this, we will need to take the query string and grab wha
 ```js
 const URL = new URL(location.href);
 const tokens = {
-    access_token: url.searchParams.get('access_token'),
-    refresh_token: url.searchParams.get('refresh_token')
+  access_token: url.searchParams.get("access_token"),
+  refresh_token: url.searchParams.get("refresh_token")
 };
 ```
 
@@ -66,89 +67,90 @@ Here is a one page example of using the proxy, assume that this is running on `l
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Spotify Proxy Test</title>
-</head>
-<body>
+  </head>
+  <body>
     <!-- The anchor tag to kick off the log in -->
     <a href="https://spotify-proxy-test.herokuapp.com/auth">Login to Spotify</a>
     <button>Get info about me!</button>
-    <script src='https://code.jquery.com/jquery-3.2.1.min.js' integrity='sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4='crossorigin='anonymous'></script>
+    <script
+      src="https://code.jquery.com/jquery-3.2.1.min.js"
+      integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+      crossorigin="anonymous"
+    ></script>
 
     <script>
-        const app = {};
-        //Object to store our tokens
-        app.tokenInfo = {};
-        //This method is used to get the token for every request. Since a token only lasts for 3600ms we need to get a new token for each request
-        app.getToken = () => {
-            //Return a promise
-            return new Promise((resolve,reject) => {
-                //Make the request to get the token
-                $.ajax({
-                    url: 'https://spotify-proxy-test.herokuapp.com/refresh',
-                    data: {
-                        //Use the refresh_token we got on load.
-                        refresh_token: app.tokenInfo.refresh_token
-                    }
-                })
-                .then((res) => {
-                    //Grab the new token and return it.
-                    const { access_token } = JSON.parse(res);
-                    resolve(access_token);
-                }); 
-            });
-        };
-
-        app.getMe = () => {
-            //Before each call, use the getToken method to get a new token
-            app.getToken()
-                .then((token) => {
-                    //then use the token in a header
-                    $.ajax({
-                        url: 'https://api.spotify.com/v1/me',
-                        headers: {
-                            'Authorization' : `Bearer ${token}`
-                        }
-                    })
-                    .then(console.log);
-                });
-        };
-
-        app.events = () => {
-            $('button').on('click',() => {
-                app.getMe();
-            });
-        };     
-
-        app.init = () => {
-            //On load of the app check to see if there is a query string in the URL.
-            //If not, the user needs to click the a tag in the page
-            if(location.search !== "") {
-                const url = new URL(location.href);
-                //Grab the info
-                app.tokenInfo = {
-                    access_token: url.searchParams.get('access_token'),
-                    refresh_token: url.searchParams.get('refresh_token')
-                }
-                //call any events
-                app.events();
+      const app = {};
+      //Object to store our tokens
+      app.tokenInfo = {};
+      //This method is used to get the token for every request. Since a token only lasts for 3600s we need to get a new token for each request
+      app.getToken = () => {
+        //Return a promise
+        return new Promise((resolve, reject) => {
+          //Make the request to get the token
+          $.ajax({
+            url: "https://spotify-proxy-test.herokuapp.com/refresh",
+            data: {
+              //Use the refresh_token we got on load.
+              refresh_token: app.tokenInfo.refresh_token
             }
-        }
+          }).then(res => {
+            //Grab the new token and return it.
+            const { access_token } = JSON.parse(res);
+            resolve(access_token);
+          });
+        });
+      };
 
-        $(app.init);
+      app.getMe = () => {
+        //Before each call, use the getToken method to get a new token
+        app.getToken().then(token => {
+          //then use the token in a header
+          $.ajax({
+            url: "https://api.spotify.com/v1/me",
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
+          }).then(console.log);
+        });
+      };
+
+      app.events = () => {
+        $("button").on("click", () => {
+          app.getMe();
+        });
+      };
+
+      app.init = () => {
+        //On load of the app check to see if there is a query string in the URL.
+        //If not, the user needs to click the a tag in the page
+        if (location.search !== "") {
+          const url = new URL(location.href);
+          //Grab the info
+          app.tokenInfo = {
+            access_token: url.searchParams.get("access_token"),
+            refresh_token: url.searchParams.get("refresh_token")
+          };
+          //call any events
+          app.events();
+        }
+      };
+
+      $(app.init);
     </script>
-</body>
+  </body>
 </html>
 ```
 
 ### Client Credentials Flow (Guest Access) <a name="clientflow"></a>
 
-If you want to allow users to access your app without requiring them to authorize with Spotify, you can use the client credentials flow. Note that this flow does not require you to define any scopes in the `Reveal Config Vars` section of your deployed app (however, this also means your application can only access publicly available endpoints and data). More information on this flow can be found [here](https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow). 
+If you want to allow users to access your app without requiring them to authorize with Spotify, you can use the client credentials flow. Note that this flow does not require you to define any scopes in the `Reveal Config Vars` section of your deployed app (however, this also means your application can only access publicly available endpoints and data). More information on this flow can be found [here](https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow).
 
-Create a link that goes to the deployed servers URL and the `/guest` endpoint, where `https://someapp.herokuapp.com` is your URL for the heroku server..
+Create a link that goes to the deployed server's URL and the `/guest` endpoint, where `https://someapp.herokuapp.com` is your URL for the heroku server..
 
 ```html
 <a href="https://someapp.herokuapp.com/guest">Continue as guest</a>
@@ -161,60 +163,65 @@ Here is a one page example of using the proxy, assume that this is running on `l
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Spotify Proxy Test</title>
-</head>
-<body>
+  </head>
+  <body>
     <!-- The anchor tag to kick off the log in -->
-    <a href="https://spotify-proxy-test.herokuapp.com/guest">Continue as guest</a>
-    <script src='https://code.jquery.com/jquery-3.2.1.min.js' integrity='sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4='crossorigin='anonymous'></script>
+    <a href="https://spotify-proxy-test.herokuapp.com/guest"
+      >Continue as guest</a
+    >
+    <script
+      src="https://code.jquery.com/jquery-3.2.1.min.js"
+      integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+      crossorigin="anonymous"
+    ></script>
 
     <script>
-        const app = {};
-        //Object to store our tokens
-        app.tokenInfo = {};
+      const app = {};
+      //Object to store our tokens
+      app.tokenInfo = {};
 
-        //This method is used to get the token for every request. Since a token only lasts for 3600ms we need to get a new token for each request
-        // Note than in this instance, we are making a call to a different endpoint on the server and therefore don't need to pass a refresh token
-        app.getToken = () => {
-            //Return a promise
-            return new Promise((resolve,reject) => {
-                //Make the request to get the token
-                $.ajax({
-                    url: 'https://spotify-proxy-test.herokuapp.com/guestrefresh'
-                })
-                .then((res) => {
-                    //Grab the new token and return it.
-                    const { access_token } = JSON.parse(res);
-                    resolve(access_token);
-                }); 
-            });
-        };    
+      //This method is used to get the token for every request. Since a token only lasts for 3600s we need to get a new token for each request
+      // Note than in this instance, we are making a call to a different endpoint on the server and therefore don't need to pass a refresh token
+      app.getToken = () => {
+        //Return a promise
+        return new Promise((resolve, reject) => {
+          //Make the request to get the token
+          $.ajax({
+            url: "https://spotify-proxy-test.herokuapp.com/guestrefresh"
+          }).then(res => {
+            //Grab the new token and return it.
+            const { access_token } = JSON.parse(res);
+            resolve(access_token);
+          });
+        });
+      };
 
-        app.init = () => {
-            //On load of the app check to see if there is a query string in the URL.
-            //If not, the user needs to click the a tag in the page
-            if(location.search !== "") {
-                const url = new URL(location.href);
-                //Grab the info
-                app.tokenInfo = {
-                    access_token: url.searchParams.get('access_token'),
-                 }
-            }
+      app.init = () => {
+        //On load of the app check to see if there is a query string in the URL.
+        //If not, the user needs to click the a tag in the page
+        if (location.search !== "") {
+          const url = new URL(location.href);
+          //Grab the info
+          app.tokenInfo = {
+            access_token: url.searchParams.get("access_token")
+          };
         }
+      };
 
-        $(app.init);
+      $(app.init);
     </script>
-</body>
+  </body>
 </html>
 ```
 
 ### Multiple Authorization Flows <a name="multipleflows"></a>
 
-If you want to allow users to choose between authorizing your app via Spotify _or_ using your app in guest mode, you can enable both flows and make calls conditionally to different endpoints on your server based on whether or not the user is logged in. 
+If you want to allow users to choose between authorizing your app via Spotify _or_ using your app in guest mode, you can enable both flows and make calls conditionally to different endpoints on your server based on whether or not the user is logged in.
 
 Note that if your user accesses the app in guest mode, certain features may not be available to them and should be disabled accordingly to avoid errors. It's fairly simple to identify these features, as they will typically require you to define additional scopes in the `Reveal Config Vars` section of your Heroku server in order to access them.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-This is a deployable server that allows you to use the Spotify Authorization Code Flow to create an application with the need to build your own server.
+This is a deployable server that allows you to use either the Spotify Authorization Code Flow or Client Credentials Flow, or both, to create an application with the need to build your own server.
 
 Key | Value
 ---  | ---
@@ -21,7 +21,7 @@ Here is the workflow for working with this server in your front-end application.
 Create a link that goes to the deployed servers URL and the `/auth` endpoint.
 
 ```html
- <a href="https://someapp.herokuapp.com/auth">Login to Spotify</a>
+<a href="https://someapp.herokuapp.com/auth">Login to Spotify</a>
 ```
 
 Where `https://someapp.herokuapp.com` is your URL for the heroku server.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CLIENT_SECRET | Your client secret
 CLIENT_ID | Your client id
 APP_URL | URL for your front-end app
 SERVER_URL | URL for the deployed herokuapp
+SCOPE | The authorization scope you want the user to grant; scopes should be separated with a space. A full list of available scopes can be found [here](https://developer.spotify.com/documentation/general/guides/scopes/).
 
 When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and make sure you add the four from above.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CLIENT_SECRET | Your client secret
 CLIENT_ID | Your client id
 APP_URL | URL for your front-end app
 SERVER_URL | URL for the deployed herokuapp
-SCOPE | The authorization scope you want the user to grant; scopes should be separated with a space. A full list of available scopes can be found [here](https://developer.spotify.com/documentation/general/guides/scopes/).
+SCOPES | The authorization scopes you want the user to grant; scopes should be separated with a space. A full list of available scopes can be found [here](https://developer.spotify.com/documentation/general/guides/scopes/). If no scopes are specified, authorization will be granted only to access publicly available information.
 
 When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and make sure you add the four from above.
 

--- a/README.md
+++ b/README.md
@@ -225,4 +225,4 @@ In this instance, you will need to create two separate login links, one that goe
 <a href="https://someapp.herokuapp.com/guest">Continue as guest</a>
 ```
 
-Depending on which option the user selects, the request will be sent to the appropriate API endpoint, and will then redirect back to your application with an object containing either the guest access token or the guest and refresh access tokens.
+Depending on which option the user selects, the request will be sent to the appropriate API endpoint, and will then redirect back to your application with an object containing either the guest access token or the guest and refresh access tokens. The same base code can be used as in the examples above.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a deployable server that allows you to use either the Spotify Authorizat
 | SERVER_URL        | URL for the deployed herokuapp                                                                                                                                                                                                                                                                                                  |
 | SCOPES (optional) | The authorization scopes you want the user to grant; scopes should be separated with a space. A full list of available scopes can be found [here](https://developer.spotify.com/documentation/general/guides/scopes/). If no scopes are specified, authorization will be granted only to access publicly available information. |
 
-When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and make sure you add the five from above.
+When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and add the above.
 
 ## Workflows <a name="workflows"></a>
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here is a one page example of using the proxy, assume that this is running on `l
 
 ### Client Credentials Flow (Guest Access) <a name="clientflow"></a>
 
-If you want to allow users to access your app without authorizing Spotify, you can use the client credentials flow. Note that this flow does not require you to define any scopes in the `Reveal Config Vars` section of your deployed app (however, this also means your application can only access publicly available endpoints and data). More information on this flow can be found [here](https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow). 
+If you want to allow users to access your app without requiring them to authorize with Spotify, you can use the client credentials flow. Note that this flow does not require you to define any scopes in the `Reveal Config Vars` section of your deployed app (however, this also means your application can only access publicly available endpoints and data). More information on this flow can be found [here](https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow). 
 
 Create a link that goes to the deployed servers URL and the `/guest` endpoint, where `https://someapp.herokuapp.com` is your URL for the heroku server..
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ APP_URL | URL for your front-end app
 SERVER_URL | URL for the deployed herokuapp
 SCOPES | The authorization scopes you want the user to grant; scopes should be separated with a space. A full list of available scopes can be found [here](https://developer.spotify.com/documentation/general/guides/scopes/). If no scopes are specified, authorization will be granted only to access publicly available information.
 
-When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and make sure you add the four from above.
+When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and make sure you add the five from above.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SCOPES | The authorization scopes you want the user to grant; scopes should be s
 
 When you deploy to Heroku go to your application in the dashboard and click on the settings tab. There you can click `Reveal Config Vars`, and make sure you add the five from above.
 
-## Workflow
+## Workflow: Authorization Code Flow
 
 Here is the workflow for working with this server in your front-end application.
 
@@ -48,6 +48,93 @@ const tokens = {
     refresh_token: url.searchParams.get('refresh_token')
 };
 ```
+
+Here is a one page example of using the proxy, assume that this is running on `localhost:3400` and that has been added as the `APP_URL` for the proxy on heroku.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Spotify Proxy Test</title>
+</head>
+<body>
+    <!-- The anchor tag to kick off the log in -->
+    <a href="https://spotify-proxy-test.herokuapp.com/auth">Login to Spotify</a>
+    <button>Get info about me!</button>
+    <script src='https://code.jquery.com/jquery-3.2.1.min.js' integrity='sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4='crossorigin='anonymous'></script>
+
+    <script>
+        const app = {};
+        //Object to store our tokens
+        app.tokenInfo = {};
+        //This method is used to get the token for every request. Since a token only lasts for 3600ms we need to get a new token for each request
+        app.getToken = () => {
+            //Return a promise
+            return new Promise((resolve,reject) => {
+                //Make the request to get the token
+                $.ajax({
+                    url: 'https://spotify-proxy-test.herokuapp.com/refresh',
+                    data: {
+                        //Use the refresh_token we got on load.
+                        refresh_token: app.tokenInfo.refresh_token
+                    }
+                })
+                .then((res) => {
+                    //Grab the new token and return it.
+                    const { access_token } = JSON.parse(res);
+                    resolve(access_token);
+                }); 
+            });
+        };
+
+        app.getMe = () => {
+            //Before each call, use the getToken method to get a new token
+            app.getToken()
+                .then((token) => {
+                    //then use the token in a header
+                    $.ajax({
+                        url: 'https://api.spotify.com/v1/me',
+                        headers: {
+                            'Authorization' : `Bearer ${token}`
+                        }
+                    })
+                    .then(console.log);
+                });
+        };
+
+        app.events = () => {
+            $('button').on('click',() => {
+                app.getMe();
+            });
+        };     
+
+        app.init = () => {
+            //On load of the app check to see if there is a query string in the URL.
+            //If not, the user needs to click the a tag in the page
+            if(location.search !== "") {
+                const url = new URL(location.href);
+                //Grab the info
+                app.tokenInfo = {
+                    access_token: url.searchParams.get('access_token'),
+                    refresh_token: url.searchParams.get('refresh_token')
+                }
+                //call any events
+                app.events();
+            }
+        }
+
+        $(app.init);
+    </script>
+</body>
+</html>
+```
+
+## Workflow: Client Credentials Flow
+
+If you want to allow users to access your app without authorizing Spotify, you can use the client credentials flow. 
 
 Here is a one page example of using the proxy, assume that this is running on `localhost:3400` and that has been added as the `APP_URL` for the proxy on heroku.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Create a link that goes to the deployed servers URL and the `/auth` endpoint, wh
 <a href="https://someapp.herokuapp.com/auth">Login to Spotify</a>
 ```
 
-When the user clicks on the link, it will send the request to Spotify, which then redirects to the servers `/redirect` endpoint. From there it will take the returned data and then send the proper info to the next stop, which is the token step. Once that is completed it will redirect to your application with an object that looks like this as a query string.
+When the user clicks on the link, it will send the request to Spotify, which then redirects to the server's `/redirect` endpoint. From there it will take the returned data and then send the proper info to the next stop, which is the token step. Once that is completed it will redirect to your application with an object that looks like this as a query string.
 
 On Spotify in the application dashboard for the API click the `edit settings` button and make sure you add `https://someapp.herokuapp.com/redirect` in the redirects URI's section.
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ app.get('/guest', (req,res) => {
             'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
         }
     },(err,response,body) => {
-        res.send(body);
+        res.redirect(`${process.env.APP_URL}?${qs.stringify(body)}`);
     });
 });
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ app.get('/auth',(req,res) => {
         qs.stringify({
             response_type: 'code',
             client_id: process.env.CLIENT_ID,
-            redirect_uri: `${process.env.SERVER_URL}/redirect`
+            redirect_uri: `${process.env.SERVER_URL}/redirect`,
+            scope: `${process.env.SCOPE}`
         }));
 });
 

--- a/index.js
+++ b/index.js
@@ -63,4 +63,22 @@ app.get('/refresh',(req,res) => {
     });
 });
 
+// Client credentials flow - guest authorization procedure
+app.get('/guest', (req,res) => {
+    const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`  
+
+    request({
+        url: 'https://accounts.spotify.com/api/token',
+        method: 'post',
+        form: {
+            grant_type: 'client_credentials',
+        },
+        headers: {
+            'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
+        }
+    },(err,response,body) => {
+        res.send(body);
+    });
+});
+
 app.listen(process.env.PORT || '3400');

--- a/index.js
+++ b/index.js
@@ -1,104 +1,124 @@
-require('dotenv').config();
-const request = require('request');
-const express = require('express');
-const qs = require('querystring');
+require("dotenv").config();
+const request = require("request");
+const express = require("express");
+const qs = require("querystring");
 const app = express();
 
-app.use(express.static('.'));
+app.use(express.static("."));
 
-app.use(function (req, res, next) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Credentials', true);
-    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Content-length, Accept, x-access-token');
-    res.header('Access-Control-Allow-Methods', 'POST, GET, PUT, DELETE, OPTIONS');
-    next();
-}); 
-
-app.get('/auth',(req,res) => {
-
-    res.redirect('https://accounts.spotify.com/authorize?' +
-        qs.stringify({
-            response_type: 'code',
-            client_id: process.env.CLIENT_ID,
-            redirect_uri: `${process.env.SERVER_URL}/redirect`,
-            scope: `${process.env.SCOPES}`
-        }));
+app.use(function(req, res, next) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Credentials", true);
+  res.header(
+    "Access-Control-Allow-Headers",
+    "Origin, X-Requested-With, Content-Type, Content-length, Accept, x-access-token"
+  );
+  res.header("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
+  next();
 });
 
-app.get('/redirect',(req,res) => {
-    const code = req.url.match(/code=([\w\d-_.]+)/)[1];
-    const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`
-    request({
-        url: 'https://accounts.spotify.com/api/token',
-        method: 'POST',
-        form: {
-            grant_type: 'authorization_code',
-            code: code,
-            redirect_uri: `${process.env.SERVER_URL}/redirect`
-        },
-        json: true,
-        headers: {
-            'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
-        }
-    },(err,response,body) => {
-        res.redirect(`${process.env.APP_URL}?${qs.stringify(body)}`);
-    });
+app.get("/auth", (req, res) => {
+  let config = {
+    response_type: "code",
+    client_id: process.env.CLIENT_ID,
+    redirect_uri: `${process.env.SERVER_URL}/redirect`
+  };
+
+  if (process.env.SCOPES) {
+    config.scope = process.env.SCOPES;
+  }
+
+  res.redirect(
+    "https://accounts.spotify.com/authorize?" + qs.stringify(config)
+  );
 });
 
-app.get('/refresh',(req,res) => {
-    const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`  
+app.get("/redirect", (req, res) => {
+  const code = req.url.match(/code=([\w\d-_.]+)/)[1];
+  const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`;
+  request(
+    {
+      url: "https://accounts.spotify.com/api/token",
+      method: "POST",
+      form: {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: `${process.env.SERVER_URL}/redirect`
+      },
+      json: true,
+      headers: {
+        Authorization: `Basic ${new Buffer(base64Token).toString("base64")}`
+      }
+    },
+    (err, response, body) => {
+      res.redirect(`${process.env.APP_URL}?${qs.stringify(body)}`);
+    }
+  );
+});
 
-    request({
-        url: 'https://accounts.spotify.com/api/token',
-        method: 'post',
-        form: {
-            grant_type: 'refresh_token',
-            refresh_token: req.query.refresh_token
-        },
-        headers: {
-            'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
-        }
-    },(err,response,body) => {
-        res.send(body);
-    });
+app.get("/refresh", (req, res) => {
+  const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`;
+
+  request(
+    {
+      url: "https://accounts.spotify.com/api/token",
+      method: "post",
+      form: {
+        grant_type: "refresh_token",
+        refresh_token: req.query.refresh_token
+      },
+      headers: {
+        Authorization: `Basic ${new Buffer(base64Token).toString("base64")}`
+      }
+    },
+    (err, response, body) => {
+      res.send(body);
+    }
+  );
 });
 
 // Client credentials flow - guest authorization procedure
-app.get('/guest', (req,res) => {
-    const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`  
+app.get("/guest", (req, res) => {
+  const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`;
 
-    request({
-        url: 'https://accounts.spotify.com/api/token',
-        method: 'POST',
-        form: {
-            grant_type: 'client_credentials',
-        },
-        json: true,
-        headers: {
-            'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
-        }
-    },(err,response,body) => {
-        // res.send(body);
-        res.redirect(`${process.env.APP_URL}?${qs.stringify(body)}`);
-    });
+  request(
+    {
+      url: "https://accounts.spotify.com/api/token",
+      method: "POST",
+      form: {
+        grant_type: "client_credentials"
+      },
+      json: true,
+      headers: {
+        Authorization: `Basic ${new Buffer(base64Token).toString("base64")}`
+      }
+    },
+    (err, response, body) => {
+      // res.send(body);
+      res.redirect(`${process.env.APP_URL}?${qs.stringify(body)}`);
+    }
+  );
 });
 
 //Refresh guest token
-app.get('/guestrefresh', (req, res) => {
-    const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`
+app.get("/guestrefresh", (req, res) => {
+  const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`;
 
-    request({
-        url: 'https://accounts.spotify.com/api/token',
-        method: 'POST',
-        form: {
-            grant_type: 'client_credentials',
-        },
-        headers: {
-            'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
-        }
-    }, (err, response, body) => {
-        res.send(body);
-    });
+  request(
+    {
+      url: "https://accounts.spotify.com/api/token",
+      method: "POST",
+      form: {
+        grant_type: "client_credentials"
+      },
+      headers: {
+        Authorization: `Basic ${new Buffer(base64Token).toString("base64")}`
+      }
+    },
+    (err, response, body) => {
+      res.send(body);
+    }
+  );
 });
 
-app.listen(process.env.PORT || '3400');
+app.listen(process.env.PORT || "3400");

--- a/index.js
+++ b/index.js
@@ -69,15 +69,16 @@ app.get('/guest', (req,res) => {
 
     request({
         url: 'https://accounts.spotify.com/api/token',
-        method: 'post',
+        method: 'POST',
         form: {
             grant_type: 'client_credentials',
         },
+        json: true,
         headers: {
             'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
         }
     },(err,response,body) => {
-        res.send(body);
+        // res.send(body);
         res.redirect(`${process.env.APP_URL}?${qs.stringify(body)}`);
     });
 });

--- a/index.js
+++ b/index.js
@@ -83,4 +83,22 @@ app.get('/guest', (req,res) => {
     });
 });
 
+//Refresh guest token
+app.get('/guestrefresh', (req, res) => {
+    const base64Token = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`
+
+    request({
+        url: 'https://accounts.spotify.com/api/token',
+        method: 'POST',
+        form: {
+            grant_type: 'client_credentials',
+        },
+        headers: {
+            'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
+        }
+    }, (err, response, body) => {
+        res.send(body);
+    });
+});
+
 app.listen(process.env.PORT || '3400');

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ app.get('/auth',(req,res) => {
             response_type: 'code',
             client_id: process.env.CLIENT_ID,
             redirect_uri: `${process.env.SERVER_URL}/redirect`,
-            scope: `${process.env.SCOPE}`
+            scope: `${process.env.SCOPES}`
         }));
 });
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ app.get('/guest', (req,res) => {
             'Authorization': `Basic ${new Buffer(base64Token).toString('base64')}`
         }
     },(err,response,body) => {
+        res.send(body);
         res.redirect(`${process.env.APP_URL}?${qs.stringify(body)}`);
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Reconfigured the Spotify OAuth proxy so that it can also be used to build applications that do not require the end user to give access to their Spotify account/data (i.e. guest option).

Features added:
- Added section in config variables to enter specific Spotify scopes for user to authorize (needed if any non-publicly available endpoints need to be accessed, e.g. reading user library, writing to user library, etc.)
- Added second proxy server configuration for guest access option (using Spotify Client Credentials flow)
- Added instructions in markdown file on using scopes & adding guest option to an application; organized instructions with table of contents